### PR TITLE
Add static file serving for uploaded templates.

### DIFF
--- a/client/src/pages/TemplateManagementPage.tsx
+++ b/client/src/pages/TemplateManagementPage.tsx
@@ -141,6 +141,12 @@ const TemplateManagementPage: React.FC = () => {
     },
   });
 
+  // View template function
+  const handleViewTemplate = (filePath: string) => {
+    const fileURL = `${process.env.REACT_APP_API_URL}/${filePath}`;
+    window.open(fileURL, '_blank');
+  };
+
   return (
     <Container maxWidth="md">
       <Box sx={{ mt: 4 }}>
@@ -204,13 +210,13 @@ const TemplateManagementPage: React.FC = () => {
                     <TableRow key={template.id}>
                       <TableCell>{template.templateName}</TableCell>
                       <TableCell>
-                        <a
-                          href={`${process.env.REACT_APP_API_URL}/${template.filePath}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
+                        <Button
+                          variant="outlined"
+                          color="primary"
+                          onClick={() => handleViewTemplate(template.filePath)}
                         >
                           View
-                        </a>
+                        </Button>
                       </TableCell>
                       <TableCell>
                         <Button variant="contained" onClick={() => handleOpenDialog(template)}>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,9 +1,9 @@
-// src/index.ts
 import express from 'express';
 import dotenv from 'dotenv';
 import helmet from 'helmet';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
+import path from 'path';
 import logger from './logger';
 import { sequelize } from './database';
 import authRoutes from './routes/authRoutes';
@@ -24,9 +24,9 @@ app.use(cors({
   origin: ['http://localhost:3000'], // Allow requests from your frontend
 }));
 app.use(express.json());
-app.use('/api/payment', paymentRoutes);
-app.use('/api/degrees', degreeRoutes);
-app.use('/api/template', templateRoutes);
+
+// Serve static files from the 'uploads' directory
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
 // Rate Limiting
 const limiter = rateLimit({
@@ -36,6 +36,9 @@ const limiter = rateLimit({
 app.use(limiter);
 
 // Routes
+app.use('/api/payment', paymentRoutes);
+app.use('/api/degrees', degreeRoutes);
+app.use('/api/template', templateRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/universities', universityRoutes);
 app.use('/api/user', userRoutes);


### PR DESCRIPTION
Configured the Express server to serve static files from the /uploads directory, enabling uploaded templates (PDF, PNG, JPG) to be viewed directly in the browser via /uploads URLs. Updated src/index.ts with necessary static file middleware.